### PR TITLE
Apply ng-annotate consistently

### DIFF
--- a/modular/src/client/app/avengers/avengers-spaghetti.js
+++ b/modular/src/client/app/avengers/avengers-spaghetti.js
@@ -14,8 +14,9 @@
 
     angular
         .module('app.avengers')
-        .controller('Avengers', ['$http', '$log', '$q', Avengers]);
+        .controller('Avengers', Avengers);
 
+    /* @ngInject */
     function Avengers($http, $log, $q) {
         /*jshint validthis: true */
         var vm = this;

--- a/modular/src/client/app/avengers/config.route.js
+++ b/modular/src/client/app/avengers/config.route.js
@@ -5,8 +5,6 @@
         .module('app.avengers')
         .run(appRun);
 
-    // appRun.$inject = ['routehelper']
-
     /* @ngInject */
     function appRun(routehelper) {
         routehelper.configureRoutes(getRoutes());

--- a/modular/src/client/app/blocks/exception/exception-handler.provider.js
+++ b/modular/src/client/app/blocks/exception/exception-handler.provider.js
@@ -44,6 +44,7 @@
      * @param  {Object} exceptionHandler
      * @param  {Object} logger
      * @return {Function} the decorated $exceptionHandler service
+     * @ngInject
      */
     function extendExceptionHandler($delegate, exceptionHandler, logger) {
         return function(exception, cause) {

--- a/modular/src/client/app/blocks/logger/logger.js
+++ b/modular/src/client/app/blocks/logger/logger.js
@@ -5,8 +5,7 @@
         .module('blocks.logger')
         .factory('logger', logger);
 
-    logger.$inject = ['$log', 'toastr'];
-
+    /* @ngInject */
     function logger($log, toastr) {
         var service = {
             showToasts: true,

--- a/modular/src/client/app/blocks/router/routehelper.js
+++ b/modular/src/client/app/blocks/router/routehelper.js
@@ -6,8 +6,6 @@
         .provider('routehelperConfig', routehelperConfig)
         .factory('routehelper', routehelper);
 
-    routehelper.$inject = ['$location', '$rootScope', '$route', 'logger', 'routehelperConfig'];
-
     // Must configure via the routehelperConfigProvider
     function routehelperConfig() {
         /* jshint validthis:true */
@@ -25,6 +23,7 @@
         };
     }
 
+    /* @ngInject */
     function routehelper($location, $rootScope, $route, logger, routehelperConfig) {
         var handlingRouteChangeError = false;
         var routeCounts = {

--- a/modular/src/client/app/core/config.js
+++ b/modular/src/client/app/core/config.js
@@ -22,7 +22,7 @@
     core.config(configure);
 
     /* @ngInject */
-    function configure ($logProvider, $routeProvider, routehelperConfigProvider, exceptionHandlerProvider) {
+    function configure($logProvider, $routeProvider, routehelperConfigProvider, exceptionHandlerProvider) {
         // turn debugging off/on (no info or warn)
         if ($logProvider.debugEnabled) {
             $logProvider.debugEnabled(true);

--- a/modular/src/client/app/dashboard/config.route.js
+++ b/modular/src/client/app/dashboard/config.route.js
@@ -5,8 +5,6 @@
         .module('app.dashboard')
         .run(appRun);
 
-    // appRun.$inject = ['routehelper'];
-
     /* @ngInject */
     function appRun(routehelper) {
         routehelper.configureRoutes(getRoutes());

--- a/modular/src/client/app/dashboard/dashboard.js
+++ b/modular/src/client/app/dashboard/dashboard.js
@@ -5,8 +5,7 @@
         .module('app.dashboard')
         .controller('Dashboard', Dashboard);
 
-    Dashboard.$inject = ['$q', 'dataservice', 'logger'];
-
+    /* @ngInject */
     function Dashboard($q, dataservice, logger) {
 
         /*jshint validthis: true */

--- a/modular/src/client/app/layout/shell.js
+++ b/modular/src/client/app/layout/shell.js
@@ -5,8 +5,7 @@
         .module('app.layout')
         .controller('Shell', Shell);
 
-    Shell.$inject = ['$timeout', 'config', 'logger'];
-
+    /* @ngInject */
     function Shell($timeout, config, logger) {
         /*jshint validthis: true */
         var vm = this;

--- a/modular/src/client/app/layout/sidebar.js
+++ b/modular/src/client/app/layout/sidebar.js
@@ -5,8 +5,7 @@
         .module('app.layout')
         .controller('Sidebar', Sidebar);
 
-    Sidebar.$inject = ['$route', 'routehelper'];
-
+    /* @ngInject */
     function Sidebar($route, routehelper) {
         /*jshint validthis: true */
         var vm = this;

--- a/modular/src/client/app/widgets/ccSpinner.js
+++ b/modular/src/client/app/widgets/ccSpinner.js
@@ -5,8 +5,6 @@
         .module('app.widgets')
         .directive('ccSpinner', ccSpinner);
 
-    // ccSpinner.$inject = ['$window'];
-
     /* @ngInject */
     function ccSpinner ($window) {
         // Description:


### PR DESCRIPTION
Even though ng-annotate is used in the project, it isn't applied consistently. This patch removes several explicit DI annotations and adds `@ngInject` where applicable to be consistent.
