### PR TITLE
Avoid duplicate isolate scope

### DIFF
--- a/modular/src/client/app/widgets/ccSidebar.js
+++ b/modular/src/client/app/widgets/ccSidebar.js
@@ -15,10 +15,7 @@
         //  <div data-cc-sidebar class="sidebar">
         var directive = {
             link: link,
-            restrict: 'A',
-            scope: {
-                whenDoneAnimating: '&?'
-            }
+            restrict: 'A'
         };
         return directive;
 
@@ -32,11 +29,11 @@
                 var dropClass = 'dropy';
                 e.preventDefault();
                 if (!$dropdownElement.hasClass(dropClass)) {
-                    $sidebarInner.slideDown(350, scope.whenDoneAnimating);
+                    $sidebarInner.slideDown(350, attrs.whenDoneAnimating);
                     $dropdownElement.addClass(dropClass);
                 } else if ($dropdownElement.hasClass(dropClass)) {
                     $dropdownElement.removeClass(dropClass);
-                    $sidebarInner.slideUp(350, scope.whenDoneAnimating);
+                    $sidebarInner.slideUp(350, attrs.whenDoneAnimating);
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue that appears when converting the project to use Angular 1.3.

When requesting an isolate scope for the sidebar widget, this conflicts with the use of ngController as both are requesting an isolate scope. This is no longer allowed in Angular 1.3.

For reference see: https://github.com/angular/angular.js/commit/2cde927e58c8d1588569d94a797e43cdfbcedaf9 and https://docs.angularjs.org/guide/migration
