### PR TITLE
fix for paging, related issue #34

### DIFF
--- a/cc-bmean/src/client/app/attendee/attendees.js
+++ b/cc-bmean/src/client/app/attendee/attendees.js
@@ -30,7 +30,12 @@
 
         Object.defineProperty(vm.paging, 'pageCount', {
             get: function () {
-                return Math.floor(vm.attendeeFilteredCount / vm.paging.pageSize) + 1;
+                var val = 1;
+    
+                if (vm.attendeeFilteredCount % vm.paging.pageSize == 0)
+                    val = 0;
+    
+                return Math.floor(vm.attendeeFilteredCount / vm.paging.pageSize) + val;                
             }
         });
 


### PR DESCRIPTION
I noticed that there is a small bug related pageCount. 
If you have 5 of 5 records (if pageSize = 5), Paging directive generates wrong information: 1 of 2 pages, but we still should have one page.
