### PR TITLE
Adds link to instructions for installing node on OSX with Homebrew

### DIFF
--- a/modular/README.md
+++ b/modular/README.md
@@ -24,7 +24,7 @@ Demonstrates Angular modularity, testing, Gulp task automation, and more.
 ## Requirements
 
 - Install Node
-	- on OSX install [home brew](http://brew.sh/) and type `brew install node`
+	- on OSX install [home brew](https://gist.github.com/DanHerbert/9520689) and type `brew install node`
 	- on Windows install [chocolatey](https://chocolatey.org/) and type `choco install nodejs`
 - On OSX you can alleviate the need to run as sudo by [following these instructions](https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md). I highly recommend this step on OSX
 - Open terminal


### PR DESCRIPTION
There are problems. Folks are not likely to find this from the Homebrew site.