### PR TITLE
Fix. Semicolons throw this exception: "Header name must be a valid H…

### DIFF
--- a/cc-bmean/src/server/routes/index.js
+++ b/cc-bmean/src/server/routes/index.js
@@ -205,7 +205,7 @@ module.exports = function(app) {
         // Todo: Is this always the right policy? Never right? Or only for certain resources?
         res.setHeader('Cache-Control',
             'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
-        res.setHeader('Content-Type:', 'application/json');
+        res.setHeader('Content-Type', 'application/json');
         res.send(results);
     }
 


### PR DESCRIPTION
When I ran the app.js it crashed due to this error:  "Header name must be a valid HTTP Token ['Content-Type:']". It was because of the semicolons. I removed them and it solved the problem.
