### PR TITLE
ignore nested bower_components from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ obj
 node_modules
 /modular/client/build
 /modular/build
-bower_components
+**/bower_components
 **/test/coverage
 report/
 


### PR DESCRIPTION
using **/dir-syntax, guess it should be the same for node_modules
