### PR TITLE
Readme: should call node from root directory for sample (not server)

### DIFF
--- a/ng-jwt/README.md
+++ b/ng-jwt/README.md
@@ -4,7 +4,7 @@ Demonstrating Angular [JSON Web Tokens](http://tools.ietf.org/html/draft-ietf-oa
 
 ## Running
 Runs locally, no database required.
-From terminal type `cd server` then type `node server.js` and browse to port 7171
+Navigate to ng-jwt-directory in a terminal then type `node src/server/server.js` and browse to port 7171
 
 ## API Tests Using Postman
 The Chrome Postman plugin can be used to test the APIs. Import the collection from `postman.api.tests.json` to run them. The authentication token in the imported collection is specific for the hardcoded secret in the demo.


### PR DESCRIPTION
Fails with 404 from server

```
myHost:server dri$ node server.js 
** DEV **
Express server listening on port 7171
env = development
__dirname = ~/dev/ng-demos/ng-jwt/src/server  
process.cwd = ~/dev/ng-demos/ng-jwt/src/server  
GET / 404 8.173 ms - 13
```

GET 200 from root dir for sample  

```
myHost:ng-jwt dri$ node src/server/server.js 
** DEV **
Express server listening on port 7171
env = development
__dirname = ~/dev/ng-demos/ng-jwt/src/server
process.cwd = ~/dev/ng-demos/ng-jwt
GET / 200 9.676 ms - -
```
