### PR TITLE
Adjusting mongodb storageEngine for compatibility with newer mongodb …

### DIFF
--- a/cc-bmean/src/server/data/mongodb.config
+++ b/cc-bmean/src/server/data/mongodb.config
@@ -2,3 +2,4 @@
 # put your path to your MongoDB location here
 dbpath=/Users/john/_git/ng-demos/cc-bmean/src/server/data/ngCodeCamper
 rest=true
+storageEngine=mmapv1

--- a/cc-bmean/src/server/routes/index.js
+++ b/cc-bmean/src/server/routes/index.js
@@ -94,7 +94,7 @@ module.exports = function(app) {
         if (!metadata) {
             getMetadataFromScriptFile();
         }
-        res.setHeader('Content-Type:', 'application/json');
+        res.setHeader('Content-Type', 'application/json');
         res.send(metadata);
 
         function getMetadataFromScriptFile() {
@@ -205,7 +205,7 @@ module.exports = function(app) {
         // Todo: Is this always the right policy? Never right? Or only for certain resources?
         res.setHeader('Cache-Control',
             'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
-        res.setHeader('Content-Type:', 'application/json');
+        res.setHeader('Content-Type', 'application/json');
         res.send(results);
     }
 


### PR DESCRIPTION
For fix issue #75 , I added storageEngine=mmapv1 into mongodb.config file. This is important for fix errors on MongoDB versions that working as default using WiredTiger storageEngine. 
For fix issue #91, I removed colon from Content-Type on res.setHeader calls.