### PR TITLE
fix gulp-ng-annotate problem

### DIFF
--- a/modular/package.json
+++ b/modular/package.json
@@ -50,7 +50,7 @@
     "gulp-load-utils": "^0.0.4",
     "gulp-minify-css": "^0.3.7",
     "gulp-minify-html": "^0.1.4",
-    "gulp-ng-annotate": "^0.3.2",
+    "gulp-ng-annotate": "^2.0.0",
     "gulp-nodemon": "^1.0.4",
     "gulp-notify": "^1.6.0",
     "gulp-plumber": "^0.6.4",


### PR DESCRIPTION
fix `TypeError: Cannot create property '$methodName' on boolean 'false'`